### PR TITLE
Exchange parameter order of Option<T>.map/mapOrElse.

### DIFF
--- a/src/OptionT.js
+++ b/src/OptionT.js
@@ -153,11 +153,11 @@ OptionT.prototype = Object.freeze({
      *
      *  @template   T, U
      *
-     *  @param  {U} def
      *  @param  {function(T):U} fn
+     *  @param  {U} def
      *  @return {U}
      */
-    mapOr: function OptionTMapOr(def, fn) {
+    mapOr: function OptionTMapOr(fn, def) {
         if (this.is_some) {
             return fn(this.value);
         }
@@ -171,11 +171,11 @@ OptionT.prototype = Object.freeze({
      *
      *  @template   T, U
      *
-     *  @param  {function():U}  defFn
      *  @param  {function(T):U} fn
+     *  @param  {function():U}  defFn
      *  @return {U}
      */
-    mapOrElse: function OptionTMapOrElse(defFn, fn) {
+    mapOrElse: function OptionTMapOrElse(fn, defFn) {
         if (this.is_some) {
             return fn(this.value);
         }

--- a/test/test_map_or.js
+++ b/test/test_map_or.js
@@ -38,9 +38,9 @@ describe('Option<T>.mapOr()', function(){
             assert.ok(result !== EXPECTED);
 
             var none = new None();
-            result = none.mapOr(EXPECTED, function(){
+            result = none.mapOr(function(){
                 isNotCalled = false;
-            });
+            }, EXPECTED);
         });
 
         it('the returned value shoule be expected', function() {
@@ -62,10 +62,10 @@ describe('Option<T>.mapOr()', function(){
             assert.ok(result !== DEFAULT);
 
             var some = new Some("bar");
-            result = some.mapOr(DEFAULT, function(val){
+            result = some.mapOr(function(val){
                 assert.notStrictEqual(val, EXPECTED);
                 return EXPECTED;
-            });
+            }, DEFAULT);
         });
 
         it('the returned value shoule be `Some<T>`: 1', function() {

--- a/test/test_map_or_else.js
+++ b/test/test_map_or_else.js
@@ -39,11 +39,11 @@ describe('Option<T>.mapOrElse()', function(){
             assert.ok(result !== EXPECTED);
 
             var none = new None();
-            result = none.mapOrElse(function defaultFn() {
+            result = none.mapOrElse(function mapFn(){
+                mapFnIsCalled = true;
+            }, function defaultFn() {
                 defaultFnIsCalled = true;
                 return EXPECTED;
-            }, function mapFn(){
-                mapFnIsCalled = true;
             });
         });
 
@@ -73,13 +73,13 @@ describe('Option<T>.mapOrElse()', function(){
             assert.ok(result !== DEFAULT);
 
             var some = new Some("bar");
-            result = some.mapOrElse(function defaultFn() {
-                defaultFnIsCalled = true;
-                return DEFAULT;
-            }, function(val){
+            result = some.mapOrElse(function(val){
                 mapFnIsCalled = true;
                 assert.notStrictEqual(val, EXPECTED);
                 return EXPECTED;
+            }, function defaultFn() {
+                defaultFnIsCalled = true;
+                return DEFAULT;
             });
         });
 


### PR DESCRIPTION
These APIs return the result of apply a given function to inner value or the one of default value.

These names are the order of 'Map' 'Default Operations'. So use might be expect that user should pass 'map function' and 'default' in such order.

However, the current APIs' signature don't follow the rule because original Rust's APIs use 'default' and 'mapFn' order.

I think this is bad order in JavaScript worlds, this world has condirional operator `?:`, it is `true ? "true case" : "false" case`.

Therefore it should be the expected parameter order.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/50)
<!-- Reviewable:end -->
