### PR TITLE
Make `Option<T>.mapOr()` and `Option<T>.mapOrElse()` stable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## x.y.z
 
+### New Feature
+* Make `Option<T>.mapOr()` and `Option<T>.mapOrElse()` stable.
+  * We accept current signitures of these APIs as stable.
+    When Rust's upstream changes these APIs, we might follow them
+    with bumping our major version.
+  * Rust might change these API signitures. see: [rust-lang/rfcs#1025](https://github.com/rust-lang/rfcs/issues/1025).
+
+
 ## 0.8.0
 
 ### New Feature

--- a/src/OptionT.js
+++ b/src/OptionT.js
@@ -160,8 +160,6 @@ OptionT.prototype = Object.freeze({
    /**
      *  Applies a function `fn` to the contained value or returns a default `def`.
      *
-     *  XXX: this API is unstable. See: https://github.com/saneyuki/option-t.js/pull/50
-     *
      *  @template   T, U
      *
      *  @param  {U} def
@@ -169,10 +167,6 @@ OptionT.prototype = Object.freeze({
      *  @return {U}
      */
     mapOr: function OptionTMapOr(def, fn) {
-        if (process.env.NODE_ENV !== 'production') {
-            console.warn('Option<T>.mapOr() is experimental. This might be breaking changed whenever.');
-        }
-
         if (this.is_some) {
             return fn(this.value);
         }
@@ -184,8 +178,6 @@ OptionT.prototype = Object.freeze({
    /**
      *  Applies a function `fn` to the contained value or computes a default result by `defFn`.
      *
-     *  XXX: this API is unstable. See: https://github.com/saneyuki/option-t.js/pull/50
-     *
      *  @template   T, U
      *
      *  @param  {function():U}  defFn
@@ -193,10 +185,6 @@ OptionT.prototype = Object.freeze({
      *  @return {U}
      */
     mapOrElse: function OptionTMapOrElse(defFn, fn) {
-        if (process.env.NODE_ENV !== 'production') {
-            console.warn('Option<T>.mapOrElse() is experimental. This might be breaking changed whenever.');
-        }
-
         if (this.is_some) {
             return fn(this.value);
         }


### PR DESCRIPTION
We accept current signitures of these APIs as stable.
When Rust's upstream changes these APIs, we might follow them with bumping our major version.