### PR TITLE
Add OptionT.OptionBase & Mark OptionT.OptionT as a deprecated API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## x.y.z
 
+### New Feature
+
+* Add `OptionT.OptionBase`.
+  * This change also marks `OptionT.Option` as deprecated.
+  * We recommend to use this new base object instead of `OptionT.OptionT`.
+    See more details ( [#66](https://github.com/saneyuki/option-t.js/pull/66) ).
+
 
 ## 0.9.3
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ This is just interface. This is not exported to an environment
 which has no interface feature as a part of its type system like TypeScript.
 
 If you'd like to check whether the object `option` is `Option<T>` or not in such an environment,
-you can use `option instanceof OptionT.OptionT` to check it.
+you can use `option instanceof OptionT.OptionBase` to check it.
 
 But this way is not a tier-1 approach. We recommend to use a interface and type system strongly.
-Thus we don't export `OptionT` object to the type definition for TypeScript.
+Thus we don't export `OptionT.OptionBase` object to the type definition for TypeScript.
 
 
 #### `Some<T>`

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,13 @@ var Option = require('./OptionT');
 var OptionT = {
     Some: Option.Some,
     None: Option.None,
+
+    /**
+     *  @deprecated Use `OptionBase`.
+     */
     OptionT: Option.OptionT,
+
+    OptionBase: Option.OptionT,
 };
 
 module.exports = OptionT;

--- a/src/index.js
+++ b/src/index.js
@@ -32,8 +32,21 @@ var OptionT = {
 
     /**
      *  @deprecated Use `OptionBase`.
+     *  @return {OptionT.OptionBase}
      */
-    OptionT: Option.OptionT,
+    get OptionT() {
+        if (process.env.NODE_ENV !== 'production' && !!console) {
+            var LABEL = 'OptionT.OptionT is deprecated. Use OptionT.OptionBase instead.';
+            if (typeof console.warn === 'function') {
+                console.warn(LABEL);
+            }
+            else if (typeof console.warn === 'function') {
+                console.log(LABEL);
+            }
+        }
+
+        return Option.OptionT;
+    },
 
     OptionBase: Option.OptionT,
 };

--- a/test/test_inheritance.js
+++ b/test/test_inheritance.js
@@ -25,7 +25,7 @@
 'use strict';
 
 var assert = require('power-assert');
-var OptionT = require('../src/index').OptionT;
+var OptionBase = require('../src/index').OptionBase;
 var Some = require('../src/index').Some;
 var None = require('../src/index').None;
 
@@ -33,14 +33,14 @@ describe('Inheritance for `Option<T>`', function(){
     describe('`Some<T>`', function () {
         it('should be instanceof `OptionT`', function() {
             var option = new Some(1);
-            assert.ok(option instanceof OptionT);
+            assert.ok(option instanceof OptionBase);
         });
     });
 
     describe('`None`', function () {
         it('should be instanceof `OptionT`', function() {
             var option = new None();
-            assert.ok(option instanceof OptionT);
+            assert.ok(option instanceof OptionBase);
         });
     });
 });


### PR DESCRIPTION
## Motivation

This library considers 2 type systems, ECMA262 5th' one and TypeScript's one.
So there are some way to detect whether this object is a `OptionT.Option<T>`:

In ECMA262 5th, there is no interface system. Thus we can detect the
object type by checking `__proto__` like this.

```
var isOptionT = some instanceof OptionT.OptionT.
```

In TypeScript, there is interface system and static type checking!
So we can use interface to do it and it is checked statically.

```
function isSome<T>(option: Option<T>): boolean {.......}
```

By the way, this might be a problem to confuse "what API should use in
our script? `OptionT.OptionT`? or `OptionT.Option<T>?`".

So this change makes the name of 'base class' more explicitly
and marks the legacy name as deprecated.

## Change

* Add `OptionT.OptionBase`.
* Mark `OptionT.OptionT` as a deprecated API.


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/66)
<!-- Reviewable:end -->
