### PR TITLE
Remove OptionT.OptionT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## x.y.z
 
+### Breaking Change
+
+* Remove `OptionT.OptionT`. ( [#67](https://github.com/saneyuki/option-t.js/pull/67) )
+  * This was marked as deprecated in 0.10.x.
+
 
 ## 0.10.1
 

--- a/src/OptionT.js
+++ b/src/OptionT.js
@@ -330,5 +330,5 @@ None.prototype = OptionPrototype;
 module.exports = {
     Some: Some,
     None: None,
-    OptionT: OptionT,
+    OptionBase: OptionT,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -29,26 +29,7 @@ var Option = require('./OptionT');
 var OptionT = {
     Some: Option.Some,
     None: Option.None,
-
-    /**
-     *  @deprecated Use `OptionBase`.
-     *  @return {OptionT.OptionBase}
-     */
-    get OptionT() {
-        if (process.env.NODE_ENV !== 'production' && !!console) {
-            var LABEL = 'OptionT.OptionT is deprecated. Use OptionT.OptionBase instead.';
-            if (typeof console.warn === 'function') {
-                console.warn(LABEL);
-            }
-            else if (typeof console.warn === 'function') {
-                console.log(LABEL);
-            }
-        }
-
-        return Option.OptionT;
-    },
-
-    OptionBase: Option.OptionT,
+    OptionBase: Option.OptionBase,
 };
 
 module.exports = OptionT;


### PR DESCRIPTION
This was [marked as deprecated](https://github.com/saneyuki/option-t.js/pull/66) in 0.10.x

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/67)
<!-- Reviewable:end -->
