### PR TITLE
TypeScript's type definition only supports ES6 target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
   * See more details: https://github.com/Microsoft/TypeScript/pull/4352
 
 
+### Breaking Change
+
+* TypeScript's type definition only support ES6 target officially.
+  * You may continue to use this package without make your code to ES6 target.
+    See more details: [#72](https://github.com/saneyuki/option-t.js/pull/72)
+
+
 ## 0.11.0
 
 ### Breaking Change

--- a/test/test_type_definition.ts
+++ b/test/test_type_definition.ts
@@ -22,14 +22,10 @@
  * THE SOFTWARE.
  */
 
-/// <reference path="../node_modules/typescript/bin/lib.es6.d.ts"/>
 /// <reference path="../option-t.d.ts"/>
 
-'use strict';
-
-import OptionT = require('option-t');
-var Some = OptionT.Some;
-var None = OptionT.None;
+import * as OptionT from 'option-t';
+import {Option, Some, None} from 'option-t';
 
 // `Some<T>`
 (function(){

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,10 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
         "noImplicitAny": true,
         "removeComments": false,
         "preserveConstEnums": true,
         "outDir": "./__build/",
-        "target": "ES5",
+        "target": "ES6",
         "sourceMap": true
     },
     "files": [


### PR DESCRIPTION
TypeScript 1.5 and later supports ES6 target, and TypeScript's external modules will transition to ES6 module semantics.  So this change make option-t supports only ES6 target officially.

- If you don't use TypeScript, you don't have to worry about using this
  package. You can continue to use this as a common.js package.
- If you use TypeScript with targeting ~ES5, you might need to change your code. Sorry. We're supporting only targeting ES6 after this change. 
  - However, you will be able to use this type definition with to import some ES6 Promise compatible type definitions (Sorry, we have not established it yet.)
- If you use TypeScript with using inner modules (as known as 'namespace'),
  we have not supported it yet. If you'd like to need to import this package as an inner module, please file a new issue!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/72)
<!-- Reviewable:end -->
