### PR TITLE
Use 'typescript/bin/lib.es6.d.ts' for our tests.

### DIFF
--- a/option-t.d.ts
+++ b/option-t.d.ts
@@ -24,18 +24,6 @@
 
 declare module 'option-t' {
 
-    // for test
-    interface Promise<T> {
-        then<U>(
-            onFulfill: (value: T) => U | Promise<U>,
-            onReject?: (error: any) => U | Promise<U>
-        ): Promise<U>;
-
-        catch<U>(
-            onRejected: (error: any) => U | Promise<U>
-        ): Promise<U>;
-    }
-
     interface Option<T> {
         isSome: boolean;
         isNone: boolean;

--- a/test/test_type_definition.ts
+++ b/test/test_type_definition.ts
@@ -22,21 +22,11 @@
  * THE SOFTWARE.
  */
 
+/// <reference path="../node_modules/typescript/bin/lib.es6.d.ts"/>
+/// <reference path="../option-t.d.ts"/>
+
 'use strict';
 
-// for test
-interface Promise<T> {
-    then<U>(
-        onFulfill: (v: T) => U | Promise<U>,
-        onReject?: (error: any) => U | Promise<U>
-    ): Promise<U>;
-
-    catch<U>(
-        onRejected: (error: any) => U | Promise<U>
-    ): Promise<U>;
-}
-
-/// <reference path="../option-t.d.ts" />;
 import OptionT = require('option-t');
 var Some = OptionT.Some;
 var None = OptionT.None;


### PR DESCRIPTION
This proves that we don't need to define Promise like interface by self and we can use Promise type definitions from outside.

see also: #72

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/73)
<!-- Reviewable:end -->
