### PR TITLE
Fix the npm's warning about license field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,7 @@
       "url": "https://github.com/gifnksm"
     }
   ],
-  "licenses": [
-    {
-      "type": "MIT License",
-      "url": "http://opensource.org/licenses/MIT"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/saneyuki/option-t.js.git"


### PR DESCRIPTION
At now, we must follow SPDX license expression syntax version 2.0 string.
https://docs.npmjs.com/files/package.json#license

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/74)
<!-- Reviewable:end -->
