### PR TITLE
Expose OptionBase in the type definition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## x.y.z
 
+### New Feature
+
+* Expose `OptionBase` to TypeScript's type definition.
+  * __NOTICE__:
+    * In general purpose, __you must not use this object__.
+    * You can only this object if you need to cooperate with some libralies
+      like `React.PropTypes` which are use `instanceof` checking to work together with
+      others in the pure JavaScript world.
+      The typical case is [TSX (TypeScript JSX) syntax](https://github.com/Microsoft/TypeScript/wiki/JSX).
+    * Our basic stance is that _you don't use this and need not it in almost case_.
+  * See also [#77](https://github.com/saneyuki/option-t.js/pull/77)
+
 
 ## 0.12.3
 

--- a/option-t.d.ts
+++ b/option-t.d.ts
@@ -165,7 +165,28 @@ declare module 'option-t' {
         drop(): void;
     }
 
-    class Some<T> implements Option<T> {
+    /**
+     *  The base object of `Some<T>` and `None<T>`.
+     *
+     *  XXX:
+     *  In general case, __we must not use this base object__.
+     *  __Use `Option<T>` interface strongly__.
+     *
+     *  You can only this object if you need to cooperate with some libralies
+     *  like `React.PropTypes` which are use `instanceof` checking to work together with
+     *  others in the pure JavaScript world.
+     *
+     *  The typical case is TSX (TypeScript JSX) syntax.
+     *  https://github.com/Microsoft/TypeScript/wiki/JSX
+     *
+     *  Our basic stance is that _you don't use this and need not it in almost case_.
+     *
+     *  See also:
+     *  https://github.com/saneyuki/option-t.js/pull/77
+     */
+    class OptionBase {}
+
+    class Some<T> extends OptionBase implements Option<T> {
         constructor(val: T);
         isSome: boolean;
         isNone: boolean;
@@ -185,7 +206,7 @@ declare module 'option-t' {
         drop(): void;
     }
 
-    class None<T> implements Option<T> {
+    class None<T> extends OptionBase implements Option<T> {
         constructor();
         isSome: boolean;
         isNone: boolean;

--- a/test/test_type_definition.ts
+++ b/test/test_type_definition.ts
@@ -25,7 +25,7 @@
 /// <reference path="../option-t.d.ts"/>
 
 import * as OptionT from 'option-t';
-import {Option, Some, None} from 'option-t';
+import {Option, Some, None, OptionBase} from 'option-t';
 
 // `Some<T>`
 (function(){
@@ -53,6 +53,10 @@ import {Option, Some, None} from 'option-t';
     });
     var asPromise: Promise<number> = option.asPromise();
     option.drop();
+
+    if (option instanceof OptionBase) {
+        const bar: any = null;
+    }
 })();
 
 // `None<T>`
@@ -81,6 +85,10 @@ import {Option, Some, None} from 'option-t';
     });
     var asPromise: Promise<number> = option.asPromise();
     option.drop();
+
+    if (option instanceof OptionBase) {
+        const bar: any = null;
+    }
 })();
 
 // `Option<T>`


### PR DESCRIPTION
Generally, in some static typing environments as TypeScript, Flowtype, and etc, we should use an interface strongly, not to use class base typing  like `instanceof`.

However, if we cooperate with some library that provides the runtime assertion which uses `a instanceof A` like React's `React.PropTypes` for cooperating with some other vanilla JavaScript ones, we requires the checking systems which is based on `instanceof`.

So this commits exposes `OptionBase` to our type definition to cooperate with them. This is needed for real world usecases.

The typical case is [TSX (TypeScript JSX) syntax](https://github.com/Microsoft/TypeScript/wiki/JSX).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/77)
<!-- Reviewable:end -->
