### PR TITLE
Use different prototype in Some and None, not same one

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
       "name": "NAKASHIMA, Makoto",
       "email": "makoto.nksm+github@gmail.com",
       "url": "https://github.com/gifnksm"
+    },
+    {
+      "name": "AMEMIYA, Satoshi",
+      "email": "amemiya@protonmail.com",
+      "url": "https://github.com/rail44"
     }
   ],
   "license": "MIT",

--- a/src/OptionT.js
+++ b/src/OptionT.js
@@ -277,8 +277,6 @@ OptionT.prototype = Object.freeze({
     },
 });
 
-var OptionPrototype = new OptionT();
-
 /**
  *  @constructor
  *  @template   T
@@ -302,7 +300,7 @@ var Some = function OptionTSome(val) {
     this.value = val;
     Object.seal(this);
 };
-Some.prototype = OptionPrototype;
+Some.prototype = new OptionT();
 
 /**
  *  @constructor
@@ -325,7 +323,7 @@ var None = function OptionTNone() {
     this.value = undefined;
     Object.seal(this);
 };
-None.prototype = OptionPrototype;
+None.prototype = new OptionT();
 
 module.exports = {
     Some: Some,

--- a/test/test_initialize.js
+++ b/test/test_initialize.js
@@ -56,6 +56,10 @@ describe('initialization `Option<T>`', function(){
                     assert.ok(option instanceof Some);
                 });
 
+                it('should not be `None`', function() {
+                    assert.ok(!(option instanceof None));
+                });
+
                 it('`isSome` should be expected', function () {
                     assert.strictEqual(option.isSome, true);
                 });
@@ -79,6 +83,10 @@ describe('initialization `Option<T>`', function(){
 
         it('should be `None`', function() {
             assert.ok(option instanceof None);
+        });
+
+        it('should not be `Some<T>`', function() {
+            assert.ok(!(option instanceof Some));
         });
 
         it('`isSome` should be expected', function () {


### PR DESCRIPTION
Hi, saneyuki.

I found that

```javascript
new None() instanceof Some
```

returns `true` . And, 

```javascript
new Some('hoge') instanceof None
```

also returns `true` .
It is caused by using same prototype for Some and None at [here](https://github.com/saneyuki/option-t.js/blob/06be0fe1f90b3a4ac374c4d8f0950a59062d0864/src/OptionT.js#L305) and [here](https://github.com/saneyuki/option-t.js/blob/06be0fe1f90b3a4ac374c4d8f0950a59062d0864/src/OptionT.js#L328).

I make there to use different prototype in those classes, and write test case.

Thank you.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/78)
<!-- Reviewable:end -->
