### PR TITLE
refactor(type): Option<T> should be either Some<T> or None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## x.y.z
 
-
 ### Breaking Change
 
 * Remove Support iojs. [#98][pr98]
   * Support only after NodeJS 4.2 LTS.
+* `Option<T>` is just either `Some<T>` or `None<T>`. [#99][pr99]
+  * The previous interface `Option<T>` was renamed to `OptionMethods<T>`, and marked it as a private.
+    * This is just only for a defensive programming style.
+    * If you get a new problem by this change, please file a new issue. We'll consider to republish it.
 
 [pr98]: https://github.com/saneyuki/option-t.js/pull/98
+[pr99]: https://github.com/saneyuki/option-t.js/pull/99
 
 
 ### Polish

--- a/option-t.d.ts
+++ b/option-t.d.ts
@@ -28,7 +28,8 @@ declare module 'option-t' {
      *  The Option/Maybe type interface whose APIs are inspired
      *  by Rust's `std::option::Option<T>`.
      */
-    interface Option<T> {
+    export type Option<T> = Some<T> | None<T>;
+    interface OptionMethods<T> {
 
         /**
          *  Return whether the self is `Some<T>` or not.
@@ -186,7 +187,7 @@ declare module 'option-t' {
      */
     abstract class OptionBase {}
 
-    class Some<T> extends OptionBase implements Option<T> {
+    class Some<T> extends OptionBase implements OptionMethods<T> {
         constructor(val: T);
         isSome: this is Some<T>;
         isNone: this is None<T>;
@@ -206,7 +207,7 @@ declare module 'option-t' {
         drop(): void;
     }
 
-    class None<T> extends OptionBase implements Option<T> {
+    class None<T> extends OptionBase implements OptionMethods<T> {
         constructor();
         isSome: this is Some<T>;
         isNone: this is None<T>;

--- a/option-t.es6.d.ts
+++ b/option-t.es6.d.ts
@@ -26,7 +26,8 @@
  *  The Option/Maybe type interface whose APIs are inspired
  *  by Rust's `std::option::Option<T>`.
  */
-export interface Option<T> {
+export type Option<T> = Some<T> | None<T>;
+interface OptionMethods<T> {
 
     /**
      *  Return whether the self is `Some<T>` or not.
@@ -184,7 +185,7 @@ export interface Option<T> {
  */
 export abstract class OptionBase {}
 
-export class Some<T> extends OptionBase implements Option<T> {
+export class Some<T> extends OptionBase implements OptionMethods<T> {
     constructor(val: T);
     isSome: this is Some<T>;
     isNone: this is None<T>;
@@ -204,7 +205,7 @@ export class Some<T> extends OptionBase implements Option<T> {
     drop(): void;
 }
 
-export class None<T> extends OptionBase implements Option<T> {
+export class None<T> extends OptionBase implements OptionMethods<T> {
     constructor();
     isSome: this is Some<T>;
     isNone: this is None<T>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "diagnostics": true,
         "noImplicitAny": true,
         "removeComments": false,
         "preserveConstEnums": true,


### PR DESCRIPTION
## Motivation

In this case, we'd like to treat `v` as `None<T>` in the arm `B`.

```typescript
const v: Option<T> = ...;
if (v.isSome) {
  // In this arm A, `v` is `Some<T>` by the type guard method
}
else {
  // In this arm B, `v` should be `None<T>`  by the type guard method,
  // but the current `Option<T>` is just a interface, which cannot restrict type "range".
}
```

So this change make this library more Rust's enum style!

## Details

- Define `type Option<T> = Some<T> | None<T>`.
  - just as a union type.
- Rename `interface Option<T>` to `interface OptionMethods<T>`

## Drawback

####  Make `OptionMethods<T>` non-public interface (BREAKING CHANGE)

- User cannot implement `OptionMethods<T>` to their types.
- But I don't think this would be a serious problem.
   - Who want to implement a self-defined `Option<T>`?
     - They would extend `Some` or `None`.
   - If someone want to implements custom type, we'll republish `OptionMethods<T>`

## Unresolved Questions

none.

## compile perf

I think we don't have serious regression on MacBook Pro 15 (Mid 2014, 2.8GHz Intel Core i7, 16GB 1600MHz DDR3 RAM)


|             |  before   | after    |
|-------------|-----------|----------|
|Files:       |        5  |       5  |
|Lines:       |    19312  |   19314  |
|Nodes:       |    83997  |   84024  |
|Identifiers: |    32589  |   32601  |
|Symbols:     |   116894  |  117648  |
|Types:       |     5969  |    6899  |
|Memory used: |   62181K  |  67498K  |
|I/O read:    |    0.00s  |   0.00s  |
|I/O write:   |    0.00s  |   0.00s  |
|Parse time:  |    0.15s  |   0.15s  |
|Bind time:   |    0.10s  |   0.10s  |
|Check time:  |    0.48s  |   0.52s  |
|Emit time:   |    0.04s  |   0.03s  |
|Total time:  |    0.77s  |   0.80s  |



<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/99)
<!-- Reviewable:end -->
