### PR TITLE
refactor(OptionT): throw TypeError if andThen/orElse's callback returns non-Option type

### DIFF
--- a/src/OptionT.js
+++ b/src/OptionT.js
@@ -151,7 +151,7 @@ OptionT.prototype = Object.freeze({
         var mapped = fn(this.value);
         var isOption = (mapped instanceof OptionT);
         if (!isOption) {
-            throw new Error('Option<T>.flatMap()\' param `fn` should return `Option<T>`.');
+            throw new TypeError('Option<T>.flatMap()\' param `fn` should return `Option<T>`.');
         }
 
         return mapped;
@@ -248,7 +248,7 @@ OptionT.prototype = Object.freeze({
                 return value;
             }
 
-            throw new Error('Option<T>.orElse()\' param `fn` should return `Option<T>`.');
+            throw new TypeError('Option<T>.orElse()\' param `fn` should return `Option<T>`.');
         }
     },
 

--- a/test/option-t/test_flatmap.js
+++ b/test/option-t/test_flatmap.js
@@ -112,7 +112,7 @@ describe('Option<T>.flatMap()', function(){
             });
 
             it('should throw an error', function() {
-                assert.strictEqual(error instanceof Error, true);
+                assert.strictEqual(error instanceof TypeError, true);
             });
 
             it('the error message should be the expected', function() {

--- a/test/option-t/test_or_else.js
+++ b/test/option-t/test_or_else.js
@@ -84,7 +84,7 @@ describe('Option<T>.orElse()', function(){
         });
 
         it('should throw an error', function() {
-            assert.strictEqual(error instanceof Error, true);
+            assert.strictEqual(error instanceof TypeError, true);
         });
 
         it('the error message should be the expected', function() {


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/116)
<!-- Reviewable:end -->
