### PR TITLE
refactor(TypeError) throw 'TypeError' instead of 'Error'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## x.y.z
 
+### Breaking Change (Possible)
+
+- These would causes `TypeError` instread of `Error`. ([#132](https://github.com/saneyuki/option-t.js/pull/132))
+  - `Option<T>.unwrap()`
+  - `Option<T>.expect()`
+  - `Result<T, E>.unwrap()`
+  - `Result<T, E>.unwrapErr()`
+  - `Result<T, E>.expect()`
+
+
 ### Documentation
 
 * Add links to pull request for CHANGELOG.md. ([#129](https://github.com/saneyuki/option-t.js/pull/129))

--- a/src/Option.js
+++ b/src/Option.js
@@ -60,12 +60,12 @@ OptionT.prototype = Object.freeze({
      *  @template   T
      *
      *  @return {T}
-     *  @throws {Error}
+     *  @throws {TypeError}
      *      Throws if the self value equals `None`.
      */
     unwrap: function OptionTUnwrap() {
         if (!this.is_some) {
-            throw new Error('called `unwrap()` on a `None` value');
+            throw new TypeError('called `unwrap()` on a `None` value');
         }
 
         return this.value;
@@ -102,13 +102,13 @@ OptionT.prototype = Object.freeze({
      *
      *  @param  {string}  msg
      *  @return {T}
-     *  @throws {Error}
+     *  @throws {TypeError}
      *      Throws a custom error with provided `msg`
      *      if the self value equals `None`.
      */
     expect: function OptionTExpect(msg) {
         if (!this.is_some) {
-            throw new Error(msg);
+            throw new TypeError(msg);
         }
 
         return this.value;

--- a/src/Result.js
+++ b/src/Result.js
@@ -217,7 +217,7 @@ ResultBase.prototype = Object.freeze({
      *
      *  @return {T}
      *
-     *  @throws {Error}
+     *  @throws {TypeError}
      *      Throws if the self is a `Err`.
      */
     unwrap: function ResultBaseUnwrap() {
@@ -229,12 +229,12 @@ ResultBase.prototype = Object.freeze({
      *
      *  @return {E}
      *
-     *  @throws {Error}
+     *  @throws {TypeError}
      *      Throws if the self is a `Ok`.
      */
     unwrapErr: function ResultBaseUnwrapErr() {
         if (this._is_ok) {
-            throw new Error('called `unwrapErr()` on a `Ok` value');
+            throw new TypeError('called `unwrapErr()` on a `Ok` value');
         }
         else {
             return this._e;
@@ -278,7 +278,7 @@ ResultBase.prototype = Object.freeze({
      *  @param  {string}    message
      *  @return {T}
      *
-     *  @throws {Error}
+     *  @throws {TypeError}
      *      Throws the passed `message` if the self is a `Err`.
      */
     expect: function ResultBaseExpect(message) {
@@ -286,7 +286,7 @@ ResultBase.prototype = Object.freeze({
             return this._v;
         }
         else {
-            throw new Error(message);
+            throw new TypeError(message);
         }
     },
 

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -51,6 +51,7 @@ require('./result-te/test_and_then');
 require('./result-te/test_or');
 require('./result-te/test_or_else');
 require('./result-te/test_unwrap');
+require('./result-te/test_unwrap_err');
 require('./result-te/test_unwrap_or');
 require('./result-te/test_unwrap_or_else');
 require('./result-te/test_expect');

--- a/test/option-t/test_expect.js
+++ b/test/option-t/test_expect.js
@@ -57,7 +57,7 @@ describe('Option<T>.expect()', function(){
         });
 
         it('should throw the error', function() {
-            assert.strictEqual(error instanceof Error, true);
+            assert.strictEqual(error instanceof TypeError, true);
         });
 
         it('should be the expected error message', function() {

--- a/test/option-t/test_unwrap.js
+++ b/test/option-t/test_unwrap.js
@@ -56,7 +56,7 @@ describe('Option<T>.unwrap()', function(){
         });
 
         it('should throw the error', function() {
-            assert.strictEqual(error instanceof Error, true);
+            assert.strictEqual(error instanceof TypeError, true);
         });
 
         it('should be the expected error message', function() {

--- a/test/result-te/test_unwrap.js
+++ b/test/result-te/test_unwrap.js
@@ -56,7 +56,7 @@ describe('Result<T, E>.unwrap()', function(){
         });
 
         it('is instance of `Error`', function () {
-            assert.strictEqual((caught instanceof Error), true);
+            assert.strictEqual((caught instanceof TypeError), true);
         });
 
         it('the error message is expected', function () {

--- a/test/result-te/test_unwrap_err.js
+++ b/test/result-te/test_unwrap_err.js
@@ -33,22 +33,14 @@ const Err = ResultMod.Err;
 const EXPECTED_OK = 'expected_ok';
 const EXPECTED_ERR = 'expected_err';
 
-describe('Result<T, E>.expect()', function(){
-    describe('Ok<T>', function () {
-        it('expect()', function () {
-            const ok = new Ok(EXPECTED_OK);
-            assert.strictEqual(ok.expect('not expected message'), EXPECTED_OK);
-        });
-    });
-
+describe('Result<T, E>.unwrapErr()', function(){
     describe('Err<E>', function () {
-        const UNEXPECTED = 100;
         let caught = null;
 
         before(function(){
+            const result = new Ok(EXPECTED_OK);
             try {
-                const err = new Err(UNEXPECTED);
-                err.expect(EXPECTED_ERR);
+                result.unwrapErr();
             }
             catch (e) {
                 caught = e;
@@ -56,11 +48,18 @@ describe('Result<T, E>.expect()', function(){
         });
 
         it('is instance of `Error`', function () {
-            assert.strictEqual( (caught instanceof TypeError), true);
+            assert.strictEqual((caught instanceof TypeError), true);
         });
 
         it('the error message is expected', function () {
-            assert.strictEqual(caught.message, EXPECTED_ERR);
+            assert.strictEqual(caught.message, 'called `unwrapErr()` on a `Ok` value');
+        });
+    });
+
+    describe('Err<E>', function () {
+        it('should be expected value', function () {
+            const ok = new Err(EXPECTED_ERR);
+            assert.strictEqual(ok.unwrapErr(), EXPECTED_ERR);
         });
     });
 });


### PR DESCRIPTION
These should be TypeError to explain their semantics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/132)
<!-- Reviewable:end -->
