### PR TITLE
Revert "refactor(api): use literal type"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## x.y.z
+
+## Bug fix
+
+- Revert [#152](https://github.com/saneyuki/option-t.js/pull/152) by ([#155](https://github.com/saneyuki/option-t.js/issues/155)).
+
+
 ## 2.1.0
 
 ## Enhancement

--- a/src/Option.d.ts
+++ b/src/Option.d.ts
@@ -189,8 +189,8 @@ export abstract class OptionBase {}
 
 export class Some<T> extends OptionBase implements OptionMethods<T> {
     constructor(val: T);
-    isSome: true;
-    isNone: false;
+    isSome: boolean;
+    isNone: boolean;
     unwrap(): T;
     unwrapOr(def: T): T;
     unwrapOrElse(fn: RecoveryFn<T>): T;
@@ -208,8 +208,8 @@ export class Some<T> extends OptionBase implements OptionMethods<T> {
 
 export class None<T> extends OptionBase implements OptionMethods<T> {
     constructor();
-    isSome: false;
-    isNone: true;
+    isSome: boolean;
+    isNone: boolean;
     unwrap(): never;
     unwrapOr(def: T): T;
     unwrapOrElse(fn: RecoveryFn<T>): T;

--- a/src/Result.d.ts
+++ b/src/Result.d.ts
@@ -153,7 +153,7 @@ export abstract class ResultBase {}
 
 export class Ok<T, E> extends ResultBase implements ResultMethods<T, E> {
 
-    private _is_ok: true;
+    private _is_ok: boolean;
     private _v: T;
     private _e: E;
 
@@ -183,7 +183,7 @@ export class Ok<T, E> extends ResultBase implements ResultMethods<T, E> {
 // or don't restrict type parameter `E`'s upper bound to `Error`.
 export class Err<T, E> extends ResultBase implements ResultMethods<T, E> {
 
-    private _is_ok: false;
+    private _is_ok: boolean;
     private _v: T;
     private _e: E;
 


### PR DESCRIPTION
Fix https://github.com/saneyuki/option-t.js/issues/155

This reverts commit 8b18e62100df6b52e13ff37a2869c7edf26cffff.

I'll backout it by these reasons:

1. I thought this change is not useful for almost use cases.
   We use `Option<T>` as an opaque type. Of course `Option.isSome` with type guard is
   useful to know a actual type,
   but this is useful only if we calls `Option.unwrap()` or `Option.expect(msg);`.
   In other case, this narrowing does not have a concrete benefit.

2. Using literal type has some benefit to avoid calling instance method function.
   So it might have some benefit to keep `isSome` or `isNone`
   as a property instead of a type guard function
   (`isSome(): this is Some<T>`) for performance aspects.
   As a basic data structure, less overhead is very important metrics.
   However, fundamentally, `option-t` is just a wrapper object, it requires an extra allocation.
   Ultimately If we really need to achieve decreasing overhead,
   we should not use this library, instead use `null`, `undefined`,
   or other conventions to express "null" value
   (we're discussing in https://github.com/saneyuki/option-t.js/issues/151).
   Thus we must measure the actual overhead before changing our interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/156)
<!-- Reviewable:end -->
