### PR TITLE
refactor(typing): Reorganize d.ts for specializing member properties

### DIFF
--- a/src/Option.d.ts
+++ b/src/Option.d.ts
@@ -29,144 +29,6 @@ type MayRecoveryFn<T> = (this: void) => Option<T>;
 type DestructorFn<T> = (this: void, v: T) => void;
 
 /**
- *  The Option/Maybe type interface whose APIs are inspired
- *  by Rust's `std::option::Option<T>`.
- */
-export type Option<T> = Some<T> | None<T>;
-interface OptionMethods<T> {
-
-    /**
-     *  Return whether the self is `Some<T>` or not.
-     */
-    isSome: boolean;
-
-    /**
-     *  Return whether the self is `None` or not.
-     */
-    isNone: boolean;
-
-    /**
-     *  Return the inner `T` of a `Some<T>`.
-     *
-     *  @throws {Error}
-     *      Throws if the self is a `None`.
-     */
-    unwrap(): T | never;
-
-    /**
-     *  Return the contained value or a default value `def`.
-     *
-     *  @param  def
-     *      The default value which is used if the self is a `None`.
-     */
-    unwrapOr(def: T): T;
-
-    /**
-     *  Return the contained value or compute it from a closure `fn`.
-     *
-     *  @param fn
-     *      The function which produces a default value which is used if the self is a `None`.
-     */
-    unwrapOrElse(fn: RecoveryFn<T>): T;
-
-    /**
-     *  Return the inner `T` of a `Some<T>`.
-     *
-     *  @param  msg
-     *      The error message which is used if the self is a `None`.
-     *  @throws {Error}
-     *      Throws a custom error with provided `msg`
-     *      if the self value equals `None`.
-     */
-    expect(msg: string): T | never;
-
-    /**
-     *  Map an `Option<T>` to `Option<U>` by applying a function to the contained value.
-     *
-     *  @param  fn
-     *      The function which is applied to the contained value and return the result
-     *      if the self is a `Some<T>`.
-     */
-    map<U>(fn: MapFn<T, U>): Option<U>;
-
-    /**
-     *  Return `None` if the self is `None`,
-     *  otherwise call `fn` with the wrapped value and return the result.
-     *
-     *  @param  fn
-     *      The function which is applied to the contained value and return the result
-     *      if the self is a `Some<T>`. This result will be flattened once.
-     */
-    flatMap<U>(fn: FlatmapFn<T, U>): Option<U>;
-
-    /**
-     *  Apply a function `fn` to the contained value or return a default `def`.
-     *
-     *  @param  def
-     *      The default value which is used if the self is a `None`.
-     *  @param  fn
-     *      The function which is applied to the contained value and return the result
-     *      if the self is a `Some<T>`.
-     */
-    mapOr<U>(def: U, fn: MapFn<T, U>): U;
-
-    /**
-     *  Apply a function `fn` to the contained value or produce a default result by `defFn`.
-     *
-     *  @param  defFn
-     *      The function which produces a default value which is used if the self is a `None`.
-     *  @param  fn
-     *      The function which is applied to the contained value and return the result
-     *      if the self is a `Some<T>`.
-     */
-    mapOrElse<U>(def: RecoveryFn<U>, fn: MapFn<T, U>): U;
-
-    /**
-     *  Return the passed value if the self is `Some<T>`,
-     *  otherwise return `None`.
-     *
-     *  @param  optb
-     *      The value which is returned if the self is a `Some<T>`.
-     */
-    and<U>(optb: Option<U>): Option<U>;
-
-    /**
-     *  The alias of `Option<T>.flatMap()`.
-     *
-     *  @param  fn
-     */
-    andThen<U>(fn: FlatmapFn<T, U>): Option<U>;
-
-    /**
-     *  Return the self if it contains a value, otherwise return `optb`.
-     *
-     *  @param  optb
-     *      The default value which is used if the self is a `None`.
-     */
-    or(optb: Option<T>): Option<T>;
-
-    /**
-     *  Return the self if it contains a value,
-     *  otherwise call `fn` and returns the result.
-     *
-     *  @param  fn
-     *      The function which produces a default value which is used if the self is a `None`.
-     */
-    orElse(fn: MayRecoveryFn<T>): Option<T>;
-
-    /**
-     *  Finalize the self.
-     *  After this is called, the object's behavior is not defined.
-     *
-     *  This method is inspired by Rust's `Drop` trait.
-     *
-     *  @param  destructor
-     *      This would be called with the inner value if self is `Some<T>`.
-     */
-    drop(destructor?: DestructorFn<T>): void;
-}
-
-/**
  *  The base object of `Some<T>` and `None<T>`.
  *
  *  XXX:
@@ -185,12 +47,144 @@ interface OptionMethods<T> {
  *  See also:
  *  https://github.com/saneyuki/option-t.js/pull/77
  */
-export abstract class OptionBase {}
+export abstract class OptionBase<T> {
+    private readonly is_some: boolean;
+    private readonly value: T | undefined;
 
-export class Some<T> extends OptionBase implements OptionMethods<T> {
-    constructor(val: T);
-    isSome: boolean;
-    isNone: boolean;
+    /**
+     *  Return whether the self is `Some<T>` or not.
+     */
+    abstract readonly isSome: boolean;
+
+    /**
+     *  Return whether the self is `None` or not.
+     */
+    abstract readonly isNone: boolean;
+
+    /**
+     *  Return the inner `T` of a `Some<T>`.
+     *
+     *  @throws {Error}
+     *      Throws if the self is a `None`.
+     */
+    abstract unwrap(): T | never;
+
+    /**
+     *  Return the contained value or a default value `def`.
+     *
+     *  @param  def
+     *      The default value which is used if the self is a `None`.
+     */
+    abstract unwrapOr(def: T): T;
+
+    /**
+     *  Return the contained value or compute it from a closure `fn`.
+     *
+     *  @param fn
+     *      The function which produces a default value which is used if the self is a `None`.
+     */
+    abstract unwrapOrElse(fn: RecoveryFn<T>): T;
+
+    /**
+     *  Return the inner `T` of a `Some<T>`.
+     *
+     *  @param  msg
+     *      The error message which is used if the self is a `None`.
+     *  @throws {Error}
+     *      Throws a custom error with provided `msg`
+     *      if the self value equals `None`.
+     */
+    abstract expect(msg: string): T | never;
+
+    /**
+     *  Map an `Option<T>` to `Option<U>` by applying a function to the contained value.
+     *
+     *  @param  fn
+     *      The function which is applied to the contained value and return the result
+     *      if the self is a `Some<T>`.
+     */
+    abstract map<U>(fn: MapFn<T, U>): Option<U>;
+
+    /**
+     *  Return `None` if the self is `None`,
+     *  otherwise call `fn` with the wrapped value and return the result.
+     *
+     *  @param  fn
+     *      The function which is applied to the contained value and return the result
+     *      if the self is a `Some<T>`. This result will be flattened once.
+     */
+    abstract flatMap<U>(fn: FlatmapFn<T, U>): Option<U>;
+
+    /**
+     *  Apply a function `fn` to the contained value or return a default `def`.
+     *
+     *  @param  def
+     *      The default value which is used if the self is a `None`.
+     *  @param  fn
+     *      The function which is applied to the contained value and return the result
+     *      if the self is a `Some<T>`.
+     */
+    abstract mapOr<U>(def: U, fn: MapFn<T, U>): U;
+
+    /**
+     *  Apply a function `fn` to the contained value or produce a default result by `defFn`.
+     *
+     *  @param  defFn
+     *      The function which produces a default value which is used if the self is a `None`.
+     *  @param  fn
+     *      The function which is applied to the contained value and return the result
+     *      if the self is a `Some<T>`.
+     */
+    abstract mapOrElse<U>(def: RecoveryFn<U>, fn: MapFn<T, U>): U;
+
+    /**
+     *  Return the passed value if the self is `Some<T>`,
+     *  otherwise return `None`.
+     *
+     *  @param  optb
+     *      The value which is returned if the self is a `Some<T>`.
+     */
+    abstract and<U>(optb: Option<U>): Option<U>;
+
+    /**
+     *  The alias of `Option<T>.flatMap()`.
+     *
+     *  @param  fn
+     */
+    abstract andThen<U>(fn: FlatmapFn<T, U>): Option<U>;
+
+    /**
+     *  Return the self if it contains a value, otherwise return `optb`.
+     *
+     *  @param  optb
+     *      The default value which is used if the self is a `None`.
+     */
+    abstract or(optb: Option<T>): Option<T>;
+
+    /**
+     *  Return the self if it contains a value,
+     *  otherwise call `fn` and returns the result.
+     *
+     *  @param  fn
+     *      The function which produces a default value which is used if the self is a `None`.
+     */
+    abstract orElse(fn: MayRecoveryFn<T>): Option<T>;
+
+    /**
+     *  Finalize the self.
+     *  After this is called, the object's behavior is not defined.
+     *
+     *  This method is inspired by Rust's `Drop` trait.
+     *
+     *  @param  destructor
+     *      This would be called with the inner value if self is `Some<T>`.
+     */
+    abstract drop(destructor?: DestructorFn<T>): void;
+}
+
+interface Some<T> extends OptionBase<T> {
+    readonly isSome: true;
+    readonly isNone: false;
     unwrap(): T;
     unwrapOr(def: T): T;
     unwrapOrElse(fn: RecoveryFn<T>): T;
@@ -206,10 +200,14 @@ export class Some<T> extends OptionBase implements OptionMethods<T> {
     drop(destructor?: DestructorFn<T>): void;
 }
 
-export class None<T> extends OptionBase implements OptionMethods<T> {
-    constructor();
-    isSome: boolean;
-    isNone: boolean;
+interface SomeConstructor {
+    new<T>(v: T): Option<T>;
+    readonly prototype: Some<any>;
+}
+
+interface None<T> extends OptionBase<T> {
+    readonly isSome: false;
+    readonly isNone: true;
     unwrap(): never;
     unwrapOr(def: T): T;
     unwrapOrElse(fn: RecoveryFn<T>): T;
@@ -225,3 +223,16 @@ export class None<T> extends OptionBase implements OptionMethods<T> {
     drop(destructor?: DestructorFn<T>): void;
 }
 
+interface NoneConstructor {
+    new<T>(): Option<T>;
+    readonly prototype: None<any>;
+}
+
+/**
+ *  The Option/Maybe type interface whose APIs are inspired
+ *  by Rust's `std::option::Option<T>`.
+ */
+export type Option<T> = Some<T> | None<T>;
+
+export declare const Some: SomeConstructor;
+export declare const None: NoneConstructor;

--- a/test/option-t/test_type_definition.ts
+++ b/test/option-t/test_type_definition.ts
@@ -29,7 +29,7 @@ import {Option, Some, None, OptionBase} from '../../src/Option';
 
 // `Some<T>`
 (function(){
-    var option: Some<number> = new Some(1);
+    var option: Option<number> = new Some(1);
     var isSome: boolean = option.isSome;
     var isNone: boolean = option.isNone;
     var unwrap: number = option.unwrap();
@@ -61,7 +61,7 @@ import {Option, Some, None, OptionBase} from '../../src/Option';
 
 // `None<T>`
 (function(){
-    var option: None<number> = new None<number>();
+    var option: Option<number> = new None<number>();
     var isSome: boolean = option.isSome;
     var isNone: boolean = option.isNone;
     var unwrap: number = option.unwrap();

--- a/test/result-te/test_type_definition_es6.ts
+++ b/test/result-te/test_type_definition_es6.ts
@@ -30,7 +30,7 @@ import {Result, Ok, Err, ResultBase} from '../../src/Result';
 
 //  Ok<T>
 (function(){
-    const result: Ok<number, void> = new Ok<number, void>(1);
+    const result: Result<number, void> = new Ok<number, void>(1);
 
     const isOk: boolean = result.isOk();
     const isErr: boolean = result.isErr();
@@ -68,7 +68,7 @@ import {Result, Ok, Err, ResultBase} from '../../src/Result';
 
 //  Err<E>
 (function(){
-    const result: Err<number, void> = new Err<number, void>(undefined);
+    const result: Result<number, void> = new Err<number, void>(undefined);
 
     const isOk: boolean = result.isOk();
     const isErr: boolean = result.isErr();


### PR DESCRIPTION
This fixes these things:

- Define constructors and interfaces of instance with same approach with
  to define a builtin object.
- `new Some<T>(v)` and `new None<T>()` will be an object which is typed
  as `Option<T>`
- `new Ok<T, E>(v)` and `new Err<T, E>(e)` will be an object which is
  typed as `Result<T, E>`
- `Some` or `None`'s members are specialzed.

## Others

- This retries https://github.com/saneyuki/option-t.js/pull/152
- This avoid the regression: https://github.com/saneyuki/option-t.js/issues/155

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/157)
<!-- Reviewable:end -->
