### PR TITLE
Remove Reviewable boilerplate from merge commits

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,1 +1,2 @@
 status = ["continuous-integration/travis-ci/push"]
+cut-body-after = "<!-- Reviewable:start -->"


### PR DESCRIPTION
This feature was literally added to bors-ng with Reviewable in mind.

https://github.com/bors-ng/bors-ng/pull/210

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saneyuki/option-t.js/183)
<!-- Reviewable:end -->
